### PR TITLE
TP03: fixed a typo in a visitor method name

### DIFF
--- a/TP03/Mu-evalntype/MuTypingVisitor.py
+++ b/TP03/Mu-evalntype/MuTypingVisitor.py
@@ -103,7 +103,7 @@ class MuTypingVisitor(MuVisitor):
     def visitMultiplicativeExpr(self, ctx):
         raise NotImplementedError()
 
-    def visitnotExpr(self, ctx):
+    def visitNotExpr(self, ctx):
         raise NotImplementedError()
 
     def visitUnaryMinusExpr(self, ctx):


### PR DESCRIPTION
According to ANTLR conventions, the first letter after `visit` should be capitalized.