### PR TITLE
Fix typo on jumpif

### DIFF
--- a/TP05/Mu-smartcodegen/ExpandJump.py
+++ b/TP05/Mu-smartcodegen/ExpandJump.py
@@ -15,7 +15,7 @@ def replace_meta_i(old_i):
         target_label, op1, c, op2 = args
         return [
             Instru3A('cmp', op1, op2),
-            Instru3A('jumpif ', c,  target_label),
+            Instru3A('jumpif', c,  target_label),
         ]
     else:
         return


### PR DESCRIPTION
I think it's a typo but it makes the test on the name to know where it's read only instruction harder.