### PR TITLE
jump instructions should be read_only

### DIFF
--- a/TP05/Mu-smartcodegen/Instruction3A.py
+++ b/TP05/Mu-smartcodegen/Instruction3A.py
@@ -153,8 +153,11 @@ class Instru3A(Instruction):
         Otherwise, the first operand is considered as the destination
         and others are source.
         """
-        return (self.get_name() == 'print' or self.get_name().startswith("print ") or
-                self.get_name() == 'cmp')
+        return (self.get_name() == 'print'
+                or self.get_name().startswith("print ")
+                or self.get_name() == 'cmp'
+                or self.get_name() == "jumpif"
+                or self.get_name() == "jump")
 
     def __str__(self):
         s = self._ins


### PR DESCRIPTION
I think jump instructions should be read only, if not there is a problem since their firt operand is not a direction but a condition because of jump expand.